### PR TITLE
Replace SRF dataset check in gaseous_correction.py

### DIFF
--- a/eotools/gaseous_correction.py
+++ b/eotools/gaseous_correction.py
@@ -318,7 +318,7 @@ class Gas_correction_NO2:
             # load absorption rate for each gas
             k_no2_data = get_absorption('no2', dirname=dir_common)
 
-            if srf is not None:
+            if len(srf) > 0:
                 for b in self.bands:
                     assert b in srf
 


### PR DESCRIPTION
Replace SRF check in Gas_correction_O3 class init function in gaseous_correction.py. In Polymer, the SRF dataset is initialized as an empty xr.Dataset if sensor SRFs are not provided. The current check `if srf is not None:` reaches the assert statement even if there is an empty SRF dataset and results in an Exception. This commit updates the check to be the same as the one in Gas_correction_O3() on line 222.